### PR TITLE
Fix Warning

### DIFF
--- a/src/TextUI/TestRunner.php
+++ b/src/TextUI/TestRunner.php
@@ -331,7 +331,7 @@ final class TestRunner extends BaseTestRunner
             }
         }
 
-        foreach ($arguments['warnings'] as $warning) {
+        foreach ($arguments['warnings'] ?? [] as $warning) {
             $this->writeMessage('Warning', $warning);
         }
 


### PR DESCRIPTION
I've been getting this error recently

```
Warning: Invalid argument supplied for foreach()
```

I guess it's due to my upgrade to php 7.4